### PR TITLE
Made it work without using an ID

### DIFF
--- a/internal/frontend/components/exercise_row.go
+++ b/internal/frontend/components/exercise_row.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/maxence-charriere/go-app/v9/pkg/app"
 	"github.com/rtrzebinski/simple-memorizer-4/internal/models"
-	"strconv"
 )
 
 type ExerciseRow struct {
@@ -32,30 +31,27 @@ func (h *ExerciseRow) Render() app.UI {
 			app.Text(h.exercise.GoodAnswers),
 		),
 		app.Td().Style("border", "1px solid black").Body(
-			app.Button().ID(strconv.Itoa(h.exercise.Id)).Text("Delete").OnClick(func(ctx app.Context, e app.Event) {
-				// get exercise id to be deleted from the button ID,
-				// we can not use the "h.exercise.Id" because of the bug:
-				// https://github.com/maxence-charriere/go-app/issues/826
-				id, err := strconv.Atoi(ctx.JSSrc().Get("id").String())
-				if err != nil {
-					app.Log(fmt.Errorf("failed to convert row id to int: %w", err))
-				}
-				// delete exercise via API
-				err = h.parent.api.DeleteExercise(models.Exercise{Id: id})
-				if err != nil {
-					app.Log(fmt.Errorf("failed to delete exercise: %w", err))
-				}
-				// create a new rows slice to be replaced in parent component
-				rows := make([]*ExerciseRow, len(h.parent.rows))
-				for i, row := range h.parent.rows {
-					// add all rows but current one (which is being deleted)
-					if i != id && row != nil {
-						rows[i] = row
-					}
-				}
-				// replace parent rows slice with a new one - this will update the UI
-				h.parent.rows = rows
-			}),
+			app.Button().Text("Delete").OnClick(h.onDelete(h.exercise.Id), fmt.Sprintf("%p", h)),
 		),
 	)
+}
+
+func (h *ExerciseRow) onDelete(id int) app.EventHandler {
+	return func(ctx app.Context, e app.Event) {
+		// delete exercise via API
+		err := h.parent.api.DeleteExercise(models.Exercise{Id: id})
+		if err != nil {
+			app.Log(fmt.Errorf("failed to delete exercise: %w", err))
+		}
+		// create a new rows slice to be replaced in parent component
+		rows := make([]*ExerciseRow, len(h.parent.rows))
+		for i, row := range h.parent.rows {
+			// add all rows but current one (which is being deleted)
+			if i != id && row != nil {
+				rows[i] = row
+			}
+		}
+		// replace parent rows slice with a new one - this will update the UI
+		h.parent.rows = rows
+	}
 }


### PR DESCRIPTION
I had some time to look at it. When you bind the handler to the address of the component, go-app will update all the nodes when you replace them while creating the new rows omitting the deleted one.

Let me explain my (still a bit vague) interpretation about what happens:

 If this is not done, Go-App will update the **existing** nodes to reflect the values of the nodes. It basically "draws them over" what is there in the DOM. So, when you delete "1" it will render "2" in the place of "1". When you add the IDs, they will be right because they also get "overwritten" too. But the handlers will not change because they all have the same function pointer.

This is because the closure function is the same, the captured values for this call are kept at the call site. I debugged that once to understand where the closure variable actually "comes from", when the closure function itself has always the same address.

You can check this with this code:

```go
// The Render method is where the component appearance is defined.
func (h *ExerciseRow) Render() app.UI {
	f := h.onDelete(h.exercise.Id)
	app.Logf("%#v", f)

	return app.Tr().Style("border", "1px solid black").Body(
		app.Td().Style("border", "1px solid black").Body(
			app.Text(h.exercise.Id),
		),
		app.Td().Style("border", "1px solid black").Body(
			app.Text(h.exercise.Question),
		),
		app.Td().Style("border", "1px solid black").Body(
			app.Text(h.exercise.Answer),
		),
		app.Td().Style("border", "1px solid black").Body(
			app.Text(h.exercise.BadAnswers),
		),
		app.Td().Style("border", "1px solid black").Body(
			app.Text(h.exercise.GoodAnswers),
		),
		app.Td().Style("border", "1px solid black").Body(
			app.Button().Text("Delete").OnClick(f, fmt.Sprintf("%p", h)),
		),
	)
}
```

Here, f will always be the same address. So, the function factory is not part of the solution. But adding a (the right) context for the handler is.